### PR TITLE
steroids/dev#684 PBI: В компоненте DateTimeField добавить указатели, чтобы было сразу понятно, что колонки с часами и минутами не статичныx

### DIFF
--- a/src/form/TimeField/TimeFieldView.scss
+++ b/src/form/TimeField/TimeFieldView.scss
@@ -18,6 +18,8 @@
     &__dropdown { 
         background: variables.$element-background-color;
 
+        min-width: unset;
+
         @include mixins.calendar-border();
     }
 
@@ -30,7 +32,23 @@
             padding-top: 10px;
             display: flex;
             flex-flow: row nowrap;
-            column-gap: 10px;
+            column-gap: 10px;   
+        }
+
+        &:has(.TimePanelView__button_now) {
+            .TimePanelView {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+
+                &__button_now {
+                    margin-bottom: 6px;
+                }
+            }
+            .TimePanelView__footer {
+                flex-direction: column;
+            }
+            
         }
     }
 }

--- a/src/form/TimeField/TimePanelView.scss
+++ b/src/form/TimeField/TimePanelView.scss
@@ -21,29 +21,6 @@
         border-radius: variables.$input-border-radius;
     }
 
-    &__column {
-        height: 220px;
-        overflow-y: auto;
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        @include mixins.scrollWrapper(298px, 0, variables.$scroll-thumb-color, variables.$scroll-track-color);
-    }
-
-    &__cell {
-        padding: 5px 20px;
-        cursor: pointer;
-
-        &_selected {
-            background-color: variables.$primary-light;
-        }
-
-        transition: background-color 0.1s ease-in;
-        &:hover {
-            background-color: variables.$back-disabled;
-        }
-    }
-
     &__footer {
         display: flex;
         align-items: center;

--- a/src/form/TimeField/TimePanelView.tsx
+++ b/src/form/TimeField/TimePanelView.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {ITimePanelViewProps} from '@steroidsjs/core/ui/form/TimeField/TimeField';
 import {useBem} from '@steroidsjs/core/hooks';
 import _padStart from 'lodash-es/padStart';
+import TimePanelColumn from './views/TimePanelColumn';
 
 const getHours = () => {
     const result = [];
@@ -21,67 +22,51 @@ const getMinutes = () => {
     return result;
 };
 
+export interface ITimePanelColumn {
+    values: string[],
+    currentValueKey: string,
+    onUpdate: (value: string) => void,
+}
+
 function TimePanelView(props: ITimePanelViewProps) {
     const bem = useBem('TimePanelView');
     const [hours, minutes] = props.value ? props.value.split(':') : ['00', '00'];
+    const currentValues = {
+        hours,
+        minutes,
+    };
+
+    const COLUMNS : ITimePanelColumn[] = [{
+        values: getHours(),
+        currentValueKey: 'hours',
+        onUpdate: (value) => {
+            props.onSelect(value + ':' + minutes);
+        },
+    }, {
+        values: getMinutes(),
+        currentValueKey: 'minutes',
+        onUpdate: (value) => {
+            props.onSelect(hours + ':' + value);
+        },
+    }];
+
     return (
         <div className={bem(bem.block(), props.className)}>
             {props.showHeader && (
                 <div className={bem.element('header')}>
                     {props.value && (
-                        `${hours}:${minutes}`
+                        `${currentValues.hours}:${currentValues.minutes}`
                     )}
                 </div>
             )}
             <div className={bem.element('body')}>
-                <div className={bem.element('column')}>
-                    {getHours().map((value, index) => (
-                        <div
-                            key={index}
-                            className={bem.element('cell', {
-                                selected: value === hours,
-                            })}
-                            onKeyPress={e => {
-                                e.preventDefault();
-                                props.onSelect(value + ':' + minutes);
-                            }}
-                            onClick={e => {
-                                e.preventDefault();
-                                props.onSelect(value + ':' + minutes);
-                            }}
-                            role='button'
-                            tabIndex={0}
-                        >
-                            <div className={bem.element('cell-value')}>
-                                {value}
-                            </div>
-                        </div>
-                    ))}
-                </div>
-                <div className={bem.element('column')}>
-                    {getMinutes().map((value, index) => (
-                        <div
-                            key={index}
-                            className={bem.element('cell', {
-                                selected: value === minutes,
-                            })}
-                            onKeyPress={e => {
-                                e.preventDefault();
-                                props.onSelect(hours + ':' + value);
-                            }}
-                            onClick={e => {
-                                e.preventDefault();
-                                props.onSelect(hours + ':' + value);
-                            }}
-                            role='button'
-                            tabIndex={0}
-                        >
-                            <div className={bem.element('cell-value')}>
-                                {value}
-                            </div>
-                        </div>
-                    ))}
-                </div>
+                {COLUMNS.map((column) => (
+                    <TimePanelColumn
+                        key={column.currentValueKey}
+                        column={column}
+                        currentValue={currentValues[column.currentValueKey]}
+                    />
+                ))}
             </div>
             <div className={bem.element('footer', {'to-end': !props.showNow})}>
                 {props.showNow && (

--- a/src/form/TimeField/views/TimePanelColumn/TimePanelColumn.scss
+++ b/src/form/TimeField/views/TimePanelColumn/TimePanelColumn.scss
@@ -1,0 +1,48 @@
+@use "../../../../scss/variables";
+@use '../../../../scss/mixins';
+.TimePanelColumn {
+    position: relative;
+    &__column {
+        height: 220px;
+        overflow-y: auto;
+        list-style: none;
+        padding: 39px 0;
+        margin: 0;
+        @include mixins.scrollWrapper(298px, 0, variables.$scroll-thumb-color, variables.$scroll-track-color);
+    }    
+    &__cell {
+        padding: 5px 20px;
+        cursor: pointer;
+
+        &_selected {
+            background-color: variables.$primary-light;
+        }
+
+        transition: background-color 0.1s ease-in;
+        &:hover {
+            background-color: variables.$back-disabled;
+        }
+    }
+    &::before,
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 39px;
+        width: 100%;
+
+        $color: var(--element-background-color);
+        $color-hidden: rgb(from var(--element-background-color) r g b / 0%);
+
+        background: linear-gradient(to top, $color-hidden 0%, $color 100%);
+
+        pointer-events: none;
+    }
+
+    &::after {
+        bottom: 0;
+        top: unset;
+        transform: rotateZ(180deg);
+    }
+}

--- a/src/form/TimeField/views/TimePanelColumn/TimePanelColumn.scss
+++ b/src/form/TimeField/views/TimePanelColumn/TimePanelColumn.scss
@@ -1,7 +1,13 @@
 @use "../../../../scss/variables";
 @use '../../../../scss/mixins';
+
+$color: var(--element-background-color);
+$color-hidden: rgb(from var(--element-background-color) r g b / 0%);
+$background-linear-gradient: linear-gradient(to top, $color-hidden 0%, $color 100%);
+
 .TimePanelColumn {
     position: relative;
+
     &__column {
         height: 220px;
         overflow-y: auto;
@@ -10,6 +16,7 @@
         margin: 0;
         @include mixins.scrollWrapper(298px, 0, variables.$scroll-thumb-color, variables.$scroll-track-color);
     }    
+
     &__cell {
         padding: 5px 20px;
         cursor: pointer;
@@ -23,6 +30,7 @@
             background-color: variables.$back-disabled;
         }
     }
+
     &::before,
     &::after {
         content: '';
@@ -32,14 +40,10 @@
         height: 39px;
         width: 100%;
 
-        $color: var(--element-background-color);
-        $color-hidden: rgb(from var(--element-background-color) r g b / 0%);
-
-        background: linear-gradient(to top, $color-hidden 0%, $color 100%);
+        background: $background-linear-gradient;
 
         pointer-events: none;
     }
-
     &::after {
         bottom: 0;
         top: unset;

--- a/src/form/TimeField/views/TimePanelColumn/TimePanelColumn.tsx
+++ b/src/form/TimeField/views/TimePanelColumn/TimePanelColumn.tsx
@@ -15,6 +15,7 @@ export default function TimePanelColumn(props: ITimePanelColumnProps) {
     const onUpdate = (value: string) => () => {
         props.column.onUpdate(value);
     };
+
     return (
         <div className={bem.block()}>
             <div className={bem.element('column')}>

--- a/src/form/TimeField/views/TimePanelColumn/TimePanelColumn.tsx
+++ b/src/form/TimeField/views/TimePanelColumn/TimePanelColumn.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {useBem} from '@steroidsjs/core/hooks';
+
+import {ITimePanelColumn} from '../../TimePanelView';
+import './TimePanelColumn.scss';
+
+export interface ITimePanelColumnProps {
+    column: ITimePanelColumn,
+    currentValue: string,
+}
+
+export default function TimePanelColumn(props: ITimePanelColumnProps) {
+    const bem = useBem('TimePanelColumn');
+
+    const onUpdate = (value: string) => () => {
+        props.column.onUpdate(value);
+    };
+    return (
+        <div className={bem.block()}>
+            <div className={bem.element('column')}>
+                {props.column.values.map((value, index) => (
+                    <div
+                        key={index}
+                        className={bem.element('cell', {
+                            selected: value === props.currentValue,
+                        })}
+                        onKeyPress={onUpdate(value)}
+                        onClick={onUpdate(value)}
+                        role='button'
+                        tabIndex={0}
+                    >
+                        <div className={bem.element('cell-value')}>
+                            {value}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/form/TimeField/views/TimePanelColumn/index.ts
+++ b/src/form/TimeField/views/TimePanelColumn/index.ts
@@ -1,0 +1,3 @@
+import TimePanelColumn from './TimePanelColumn';
+
+export default TimePanelColumn;

--- a/src/form/TimeRangeField/TimeRangeFieldView.scss
+++ b/src/form/TimeRangeField/TimeRangeFieldView.scss
@@ -50,6 +50,12 @@
         flex-flow: row nowrap;
         column-gap: 47px;
 
+        .TimePanelView {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
         .TimePanelView__footer { 
             padding: 0;
             padding-top: 10px;

--- a/src/scss/mixins/date.scss
+++ b/src/scss/mixins/date.scss
@@ -387,7 +387,7 @@ $date-sizes: map.merge(
             margin-top: 2px;
         }
 
-        .TimePanelView__column {
+        .TimePanelView .TimePanelColumn__column {
             height: 298px;
             row-gap: 2px;
             border: none;
@@ -405,7 +405,7 @@ $date-sizes: map.merge(
                 height: 0px;
             }
 
-            .TimePanelView__cell {
+            .TimePanelColumn__cell {
                 padding: 0;
                 border-radius: variables.$radius-large;
 


### PR DESCRIPTION
Добавил размытую маску снизу колонки, чтобы было понятно, что колонку можно скроллить. 

Было:

![Снимок экрана 2025-03-18 в 12 45 06](https://github.com/user-attachments/assets/ea9d59aa-61fb-4434-9379-6b377f016757)

Стало:

![Снимок экрана 2025-03-18 в 12 47 00](https://github.com/user-attachments/assets/8d5ea0f9-6575-477e-be2b-e94916fc6612)
![Снимок экрана 2025-03-18 в 12 47 16](https://github.com/user-attachments/assets/683109fa-dd95-43be-92b2-a4cffa2ec723)

Также исправил отображение TimeField

Было:

![Снимок экрана 2025-03-18 в 12 47 59](https://github.com/user-attachments/assets/bb24b51e-3846-49a9-9aea-9bc4286fe37e)

Стало:
![Снимок экрана 2025-03-18 в 12 48 28](https://github.com/user-attachments/assets/bac23b85-24d0-4f1f-b4c1-57dfad62638a)
