### PR TITLE
steroids/dev#676 PBI: Отображать ползунок прогресса ввода пароля после начала ввода символов 

### DIFF
--- a/src/form/PasswordField/PasswordFieldView.scss
+++ b/src/form/PasswordField/PasswordFieldView.scss
@@ -152,19 +152,23 @@ $eye-filled-color: var(--eye-filled-color);
     }
 
     &__security-bar {
-        position: relative;
+        position: absolute;
         width: 100%;
         height: 4px;
         border-radius: 4px;
-        margin-top: 8px;
+
+        bottom: -12px;
 
         background-color: $security-bar-background;
+
+        opacity: 0;
+        transition: 0.15s ease opacity;
 
         &::before {
             content: "";
             position: absolute;
             width: 0%;
-            height: 4px;
+            height: 100%;
             border-radius: 4px;
             transition: width 1s ease-in-out;
         }
@@ -182,6 +186,11 @@ $eye-filled-color: var(--eye-filled-color);
         &_success::before {
             width: 100%;
             background-color: variables.$success;
+        }
+    }
+    &:focus-within {
+        .PasswordFieldView__security-bar {
+            opacity: 1;
         }
     }
 

--- a/src/form/PasswordField/PasswordFieldView.scss
+++ b/src/form/PasswordField/PasswordFieldView.scss
@@ -189,7 +189,7 @@ $eye-filled-color: var(--eye-filled-color);
         }
     }
     &:focus-within {
-        .PasswordFieldView__security-bar {
+        #{$root}__security-bar {
             opacity: 1;
         }
     }


### PR DESCRIPTION
Если не отображать эту полоску до начала ввода символов, то возникнут проблемы с высотой формы:

+ Если у нас есть пространство для этой полоски всегда, а отображаем только после начала ввода, то между полями будет разное расстояние, что будет смотреться некрасиво
+ Если мы добавляем отступы вместе с полоской в момент начала ввода, то вся форма ниже поля пароля сдвинется, что неудобно пользователю
+ Если мы не добавляем расстояние для этой полосы, то между полем пароля и следующим визуально будет меньшее расстояние, чем между другими

Предлагаю отображать этот ползунок не после начала символов, а при фокусе на поле пароля.



https://github.com/user-attachments/assets/4904ff6e-d5a2-4e3b-9863-902dd379a0ad


