### PR TITLE
steroids/dev#686 refactored InputField border logic

### DIFF
--- a/src/form/InputField/InputFieldView.scss
+++ b/src/form/InputField/InputFieldView.scss
@@ -24,16 +24,74 @@ $lead-icon-disabled-color: var(--lead-icon-disabled-color);
     flex-flow: row nowrap;
     align-items: center;
 
-    height: 34px;
+    height: var(--input-height);
+
 
     font-family: variables.$font-family-nunito;
     font-weight: variables.$font-weight-sm;
     line-height: 24px;
 
+    color: variables.$text-color;
+    border-radius: var(--border-radius);
+
+
+    --input-height: #{variables.$input-height-sm};
+
+    --border-radius: #{variables.$radius-small};
+
+    --colored-border-radius: 12px;
+
+    --addon-padding: 5px 8px;
+
+    --input-font-size: #{variables.$font-size-sm};
+ 
+    //Sizes
+    &_size {
+        &_lg {
+            --input-height: #{variables.$input-height-lg};
+            --border-radius: #{variables.$radius-large};
+            --colored-border-radius: 16px;
+            --addon-padding: 16px;
+            --input-font-size: #{variables.$font-size-lg};
+            --input-border-radius: #{variables.$radius-large};
+        }
+
+        &_md {
+            --input-height: #{variables.$input-height-md};
+            --border-radius: #{variables.$radius-large};
+            --colored-border-radius: 16px;
+            --addon-padding: 11px 12px;
+            --input-font-size: #{variables.$font-size-base};
+            --input-border-radius: #{variables.$radius-large};
+        }
+    }
+
     &__input-wrapper {
+        display: flex;
+
         position: relative;
         width: 100%;
         height: 100%;
+
+        &::before {
+            content: '';
+            position: absolute;
+            z-index: 2;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+
+            pointer-events: none;
+            transform: translate(calc(var(--input-wrapper-border-width) * -1), calc(var(--input-wrapper-border-width) * -1));
+            opacity: var(--input-wrapper-border-opacity);
+            transition: opacity 150ms ease-in-out;
+
+            border-radius: var(--colored-border-radius);
+            border-width: var(--input-wrapper-border-width);
+            border-color: var(--input-wrapper-border-color);
+            border-style: solid;
+        }
     }
 
     &__input {
@@ -47,167 +105,31 @@ $lead-icon-disabled-color: var(--lead-icon-disabled-color);
         outline: none;
 
         background-color: variables.$element-field-background-color;
-        border: 1px solid variables.$element-border-color;
-        border-radius: inherit;
+        border-width: var(--input-border-width);
+        border-color: var(--input-border-color);
+        border-top-left-radius: var(--input-left-border-radius);
+        border-bottom-left-radius: var(--input-left-border-radius);
+        border-top-right-radius: var(--input-right-border-radius);
+        border-bottom-right-radius: var(--input-right-border-radius);
+        border-style: solid;
 
         white-space: nowrap; /* Запретить перенос текста */
         overflow: hidden; /* Скрыть содержимое, выходящее за границы ячейки */
         text-overflow: ellipsis; /* Добавить многоточие, если текст обрезается */
+
+        font-size: var(--input-font-size);
 
         &::placeholder {
             color: variables.$element-placeholder-color;
             font-size: inherit;
         }
 
-        &:not(:disabled):focus {
-            border-color: transparent;
-        }
-    }
-
-    //Statements
-    &::before {
-        content: '';
-        position: absolute;
-        z-index: 2;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-
-        pointer-events: none;
-        transform: translate(-1px, -1px);
-        opacity: 0;
-        transition: opacity 150ms ease-in-out;
-    }
-
-    &:not(#{$root}_disabled):focus-within::before {
-        border: 4px solid variables.$primary-light;
-        transform: translateX(-4px) translateY(-4px);
-        opacity: 1;
-    }
-
-    &:not(#{$root}_disabled):active {
-        #{$root}__input {
-            border-color: transparent;
-        }
-
-        &::before {
-            transform: translate(-1px, -1px);
-            border: 1px solid variables.$primary;
-            opacity: 1;
-        }
     }
 
     &_disabled {
         #{$root}__input {
             background-color: variables.$element-background-color-disabled;
-            border-color: transparent;
             cursor: not-allowed;
-        }
-    }
-
-    &_hasError {
-        #{$root}__input {
-            border-color: transparent;
-        }
-
-
-        &::before {
-            border: 1px solid variables.$danger;
-            border-radius: 16px;
-            transform: translateX(-1px) translateY(-1px);
-            opacity: 1;
-        }
-    }
-
-    //Sizes
-    &_size {
-        &_lg {
-            color: variables.$text-color;
-            height: variables.$input-height-lg;
-            border-radius: variables.$radius-large;
-
-            #{$root}__input {
-                font-size: variables.$font-size-lg;
-                border-radius: variables.$radius-large;
-            }
-
-            #{$root}__addon-before,
-            #{$root}__addon-after {
-                padding: 16px;
-            }
-            #{$root}__text-before,
-            #{$root}__text-after {
-                padding: 16px 3px;
-            }
-
-            &::before {
-                border-radius: variables.$radius-large;
-            }
-
-            &:focus-within::before {
-                border-radius: 16px;
-            }
-        }
-
-        &_md {
-            color: variables.$text-color;
-            height: variables.$input-height-md;
-            border-radius: variables.$radius-large;
-
-            #{$root}__input {
-                border-radius: variables.$radius-large;
-                font-size: variables.$font-size-base;
-            }
-
-            #{$root}__addon-before,
-            #{$root}__addon-after,
-            #{$root}__text-before,
-            #{$root}__text-after {
-                padding: 11px 12px;
-            }
-
-            #{$root}__text-before,
-            #{$root}__text-after {
-                padding: 11px 3px;
-            }
-
-            &::before {
-                border-radius: variables.$radius-medium;
-            }
-
-            &:focus-within::before {
-                border-radius: 16px;
-            }
-        }
-
-        &_sm {
-            color: variables.$text-color;
-            height: variables.$input-height-sm;
-            border-radius: variables.$radius-small;
-
-            #{$root}__input {
-                font-size: variables.$font-size-sm;
-                border-radius: variables.$radius-small;
-            }
-
-            #{$root}__addon-before,
-            #{$root}__addon-after {
-                padding: 5px 8px;
-            }
-
-            #{$root}__text-before,
-            #{$root}__text-after {
-                padding: 5px 3px;
-            }
-
-            &::before {
-                border-radius: variables.$radius-small;
-            }
-
-            &:focus-within::before {
-                border-radius: 12px;
-            }
         }
     }
 
@@ -279,49 +201,81 @@ $lead-icon-disabled-color: var(--lead-icon-disabled-color);
         }
     }
 
-    &_hasAddonBefore {
-        #{$root}__input {
-            border-top-left-radius: 0;
-            border-bottom-left-radius: 0;
-            border: none;
-        }
-        &::before {
-            border: 1px solid variables.$element-border-color;
-            opacity: 1;
-        }
-    }
-
-    &_hasAddonAfter {
-        #{$root}__input {
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
-        }
-        &::before {
-            border: 1px solid variables.$element-border-color;
-            opacity: 1;
-        }
-    }
-
     &__text-before,
     &__text-after {
         flex-shrink: 0;
+        padding: 0 6px;
     }
 
     &__addon-before,
     &__addon-after {
         flex-shrink: 0;
-        padding: 11px 12px;
+        padding: var(--addon-padding);
         background-color: variables.$element-background-color-disabled;
         color: variables.$text-color;
     }
 
+    // BORDERS 
+    --input-border-radius: #{variables.$radius-small};
+    --input-border-width: 1px;
+    --input-border-color: #{variables.$element-border-color};
+    --input-left-border-radius: var(--input-border-radius);
+    --input-right-border-radius: var(--input-border-radius);
+
+    --input-wrapper-border-width: 1px;
+    --input-wrapper-border-color: transparent;
+    --input-wrapper-border-opacity: 0;
+
+    &_hasError {
+        --input-wrapper-border-width: 1px;
+        --input-wrapper-border-color: #{variables.$danger};
+        --input-wrapper-border-opacity: 1;
+
+        --input-border-color: transparent;
+    }
+
+    &_hasAddon {
+        --input-wrapper-border-width: 1px;
+        --input-wrapper-border-color: #{variables.$element-border-color};
+        --input-wrapper-border-opacity: 1;
+
+        --input-border-width: 0px;
+    }
+    &_hasAddonBefore {
+        --input-left-border-radius: 0;
+    }
+    &_hasAddonAfter {
+        --input-right-border-radius: 0;
+    }
+
+    &:not(&_disabled) {
+        &:focus-within {
+            --input-wrapper-border-width: 4px;
+            --input-wrapper-border-color: #{variables.$primary-light};
+            --input-wrapper-border-opacity: 1;
+
+            --input-border-color: transparent;
+        }
+        &:active {
+            --input-wrapper-border-width: 1px;
+            --input-wrapper-border-color: #{variables.$primary};
+            --input-wrapper-border-opacity: 1;
+
+            --input-border-color: transparent;
+        }
+    }
+
+    &_disabled {
+        --input-border-color: transparent;
+    }
+
     &__addon-before {
-        border-top-left-radius: inherit;
-        border-bottom-left-radius: inherit;
+        border-top-left-radius: var(--input-border-radius);
+        border-bottom-left-radius: var(--input-border-radius);
     }
 
     &__addon-after {
-        border-top-right-radius: inherit;
-        border-bottom-right-radius: inherit;
+        border-top-right-radius: var(--input-border-radius);
+        border-bottom-right-radius: var(--input-border-radius);
     }
 }

--- a/src/form/InputField/InputFieldView.tsx
+++ b/src/form/InputField/InputFieldView.tsx
@@ -30,17 +30,17 @@ export default function InputFieldView(props: IInputFieldViewProps) {
             )}
             style={props.style}
         >
-            {props.addonBefore && (
-                <span className={bem.element('addon-before')}>
-                    {props.addonBefore}
-                </span>
-            )}
             {props.textBefore && (
                 <span className={bem.element('text-before')}>
                     {props.textBefore}
                 </span>
             )}
             <div className={bem.element('input-wrapper')}>
+                {props.addonBefore && (
+                    <span className={bem.element('addon-before')}>
+                        {props.addonBefore}
+                    </span>
+                )}
                 {props.leadIcon && renderIcon(props.leadIcon,
                     {
                         className: bem.element('lead-icon'),
@@ -90,15 +90,15 @@ export default function InputFieldView(props: IInputFieldViewProps) {
                         onClick={props.onClear}
                     />
                 )}
+                {props.addonAfter && (
+                    <span className={bem.element('addon-after')}>
+                        {props.addonAfter}
+                    </span>
+                )}
             </div>
             {props.textAfter && (
                 <span className={bem.element('text-after')}>
                     {props.textAfter}
-                </span>
-            )}
-            {props.addonAfter && (
-                <span className={bem.element('addon-after')}>
-                    {props.addonAfter}
                 </span>
             )}
         </div>


### PR DESCRIPTION
Изменил логику отображения обводки. Теперь textBefore и textAfter никогда не включены в обводку, а addonBefore и addonAfter всегда включены в обводку.

Было:
![Снимок экрана 2025-03-18 в 17 11 28](https://github.com/user-attachments/assets/378921b6-8757-4037-aeb8-718e916a5766)

Стало:

![Снимок экрана 2025-03-18 в 17 11 55](https://github.com/user-attachments/assets/014d3582-cf47-4ad9-8701-2684210cbc90)

![Снимок экрана 2025-03-18 в 17 12 05](https://github.com/user-attachments/assets/1e781d81-d352-4445-81c4-ab7c34cd8bc3)

Возможность заполнять это поле в demo буквами исправил вот [в этом МР](https://gitlab.kozhindev.com/steroids/steroids-site/-/merge_requests/274) 
