### PR TITLE
steroids/dev#690 fixed AutoCompleteFieldView.inputBorder when focused

### DIFF
--- a/src/form/AutoCompleteField/AutoCompleteFieldView.scss
+++ b/src/form/AutoCompleteField/AutoCompleteFieldView.scss
@@ -45,24 +45,30 @@ $autocomplete-icon-color: var(--autocomplete-icon-color);
     &__input {
         width: 100%;
         padding: 0 8px;
-        border: 1px solid variables.$element-border-color;
+        outline: 1px solid variables.$element-border-color;
+        border: none;
         background-color: variables.$element-field-background-color;
         color: variables.$text-color;
-        transition: border-color 150ms ease-in-out;
+        transition: outline 150ms ease-in-out;
         font-size: inherit;
         line-height: inherit;
+
+        &:active {
+            outline-color: variables.$primary;
+        }
     }
 
     &_opened {
         #{$root}__input {
-            border-color: variables.$primary;
+            outline-width: 4px;
+            outline-color: variables.$primary-light;
         }
     }
 
     &_disabled {
         #{$root}__input {
             background-color: variables.$element-background-color-disabled;
-            border-color: transparent;
+            outline-color: transparent;
             cursor: not-allowed;
         }
     }


### PR DESCRIPTION
Добавил AutoCompleteFieldView такой же бордер, когда он в фокусе, как у других инпутов

Было:

https://github.com/user-attachments/assets/736587fd-1e24-4873-9617-a331849e1822

Стало:

https://github.com/user-attachments/assets/97e821ce-4f4d-4810-aa05-1e0f9d76b3c7

