### PR TITLE
steroids/dev#762 fixed active + today + hover Calendar.Day hidding

### DIFF
--- a/src/content/Calendar/CalendarView.scss
+++ b/src/content/Calendar/CalendarView.scss
@@ -212,14 +212,6 @@ $calendar-border-color: var(--calendar-border-color);
         background-color: $day-background-color-hover;
     }
 
-    .DayPicker-Day--today:hover {
-        background-color: transparent;
-
-        .CalendarView__day {
-            transition: background-color 150ms ease-in-out;
-        }
-    }
-
     &__day {
         position: relative;
         z-index: 1;


### PR DESCRIPTION
Before:


https://github.com/user-attachments/assets/f7349a0f-9bd7-4cd5-853b-ae0cce54188e


After:

https://github.com/user-attachments/assets/38f3a64e-e12d-4099-ac79-e8a5d769876c


Строки с background-color:hidden, похоже, нужны были для тёмной темы, там скрывается это выглядит вот так:
Before

https://github.com/user-attachments/assets/7ea5bbe4-2b27-4ee9-9f2b-d3b7d943ec36

After:

https://github.com/user-attachments/assets/d06f52d1-f1d8-46a0-b7c6-546c5e4a9f05

Думаю, т.к. другие дни (не сегодня) не меняют свой цвет при ховере, то и сегодняшний день не должен

