### PR TITLE
Draft: steroids/dev#747 fixed debounce

### DIFF
--- a/src/form/InputField/InputFieldView.tsx
+++ b/src/form/InputField/InputFieldView.tsx
@@ -9,6 +9,8 @@ import renderIcon from '../../utils/renderIcon';
 export default function InputFieldView(props: IInputFieldViewProps) {
     const bem = useBem('InputFieldView');
 
+    const {value, ...inputProps} = props.inputProps;
+
     return (
         <div
             className={bem(
@@ -57,7 +59,7 @@ export default function InputFieldView(props: IInputFieldViewProps) {
                                     size: props.size,
                                 }),
                             )}
-                            {...props.inputProps}
+                            {...inputProps}
                             type={props.inputProps.type}
                             placeholder={props.placeholder}
                             disabled={props.disabled}
@@ -73,7 +75,7 @@ export default function InputFieldView(props: IInputFieldViewProps) {
                                     size: props.size,
                                 }),
                             )}
-                            {...props.inputProps}
+                            {...inputProps}
                             type={props.inputProps.type}
                             placeholder={props.placeholder}
                             disabled={props.disabled}

--- a/src/form/NumberField/NumberFieldView.tsx
+++ b/src/form/NumberField/NumberFieldView.tsx
@@ -8,6 +8,8 @@ import Icon from '@steroidsjs/core/ui/content/Icon';
 export default function NumberFieldView(props: INumberFieldViewProps) {
     const bem = useBem('NumberFieldView');
 
+    const {value, ...inputProps} = props.inputProps;
+
     return (
         <div
             className={bem(
@@ -25,7 +27,7 @@ export default function NumberFieldView(props: INumberFieldViewProps) {
                 className={bem(
                     bem.element('input'),
                 )}
-                {...props.inputProps}
+                {...inputProps}
                 onWheel={event => event.currentTarget.blur()}
                 id={props.id}
             />


### PR DESCRIPTION
В общем, ситуация такая:

До этого МР debounce работал на steroids site, но не работал на boilerplate. Это так, потому что в steroids-site есть зависимость `steroidsjs/ssr`. Если в boilerplate установить её, то debounce будет работать и там (установить достаточно, подключать, адаптировать и пр. не нужно). Я почти уверен, что это из-за того, что в `steroids/ssr` есть зависимость `steroids/core@3.0.0-beta.52`, но я очень сильно затрудняюсь объяснить как зависимость зависимости связана с этим 😵‍💫. 

Без `steroids/ssr` debounce не работает, потому что в `InputFieldView`, передаётся `props.inputProps.value`, которое изменяется только после того, как отработает `debounce`, и этот `value` передаётся в `input`. Если убрать `value` из `props.inputProps`, `debounce` будет работать так, как ожидается. 

Но такое решение не подходит, т.к. если мы отвязываемся во view части от `inputProps.value`, перестаёт работать логика привязанная к этому. (Например filled class у поля ставится с debounce задержкой, увеличение/уменьшение стрелочками в `NumberField` не работает, min max у `NumberField` не работают).

Есть идеи почему работа debounce зависит от `steroidsjs/ssr`? Или может быть какая-нибудь другая идея, как можно исправить всё это счастье?